### PR TITLE
QC batch effects supplementary figure

### DIFF
--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -6,12 +6,17 @@ import numpy as np
 import pandas as pd
 import matplotlib
 from ark.utils.plot_utils import cohort_cluster_plot
+from toffy import qc_comp, qc_metrics_plots
+from alpineer import io_utils
+
 
 matplotlib.rcParams['pdf.fonttype'] = 42
 matplotlib.rcParams['ps.fonttype'] = 42
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+import matplotlib.gridspec as gridspec
+from matplotlib.colors import ListedColormap, Normalize
 
 # Panel validation
 
@@ -20,6 +25,161 @@ import seaborn as sns
 
 
 # QC
+qc_metrics = ["Non-zero mean intensity"]
+channel_exclude = ["chan_39", "chan_45", "CD11c_nuc_exclude", "CD11c_nuc_exclude_update",
+                   "FOXP3_nuc_include", "FOXP3_nuc_include_update", "CK17_smoothed",
+                   "FOXP3_nuc_exclude_update", "chan_48", "chan_141", "chan_115", "LAG3"]
+
+## FOV spatial location
+cohort_path = "/Volumes/Shared/Noah Greenwald/TONIC_Cohort/image_data/samples"
+qc_tma_metrics_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/qc_metrics/qc_tma_metrics"
+if not os.path.exists(qc_tma_metrics_dir):
+    os.makedirs(qc_tma_metrics_dir)
+
+fovs = io_utils.list_folders(cohort_path)
+tmas = list(set([fov.split('_R')[0] for fov in fovs]))
+
+qc_tmas = qc_comp.QCTMA(
+    qc_metrics=qc_metrics,
+    cohort_path=cohort_path,
+    metrics_dir=qc_tma_metrics_dir,
+)
+
+qc_tmas.compute_qc_tma_metrics(tmas=tmas)
+qc_tmas.qc_tma_metrics_zscore(tmas=tmas, channel_exclude=channel_exclude)
+qc_metrics_plots.qc_tmas_metrics_plot(qc_tmas=qc_tmas, tmas=tmas, save_figure=True, dpi=300)
+
+## longitudinal controls
+control_path = "/Volumes/Shared/Noah Greenwald/TONIC_Cohort/image_data/controls"
+qc_control_metrics_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/qc_metrics/qc_longitudinal_control"
+if not os.path.exists(qc_control_metrics_dir):
+    os.makedirs(qc_control_metrics_dir)
+
+folders = io_utils.list_folders(control_path, "TMA3_")
+control_substrs = [name.split("_")[2] + '_' + name.split("_")[3] if len(name.split("_")) == 4
+                   else name.split("_")[2] + '_' + name.split("_")[3]+'_' + name.split("_")[4]
+                   for name in folders]
+
+all_folders = io_utils.list_folders(control_path)
+for i, control in enumerate(control_substrs):
+    control_sample_name = control
+    print(control)
+    if control == 'tonsil_bottom':
+        fovs = [folder for folder in all_folders if control in folder and len(folder) <= 25]
+    else:
+        fovs = [folder for folder in all_folders if control in folder]
+
+    qc_control = qc_comp.QCControlMetrics(
+        qc_metrics=qc_metrics,
+        cohort_path=control_path,
+        metrics_dir=qc_control_metrics_dir,
+    )
+
+    qc_control.compute_control_qc_metrics(
+        control_sample_name=control_sample_name,
+        fovs=fovs,
+        channel_exclude=channel_exclude,
+        channel_include=None,
+    )
+
+    qc_metrics_plots.longitudinal_control_heatmap(
+        qc_control=qc_control, control_sample_name=control_sample_name, save_figure=True, dpi=300
+    )
+
+dfs = []
+for control in control_substrs:
+    df = pd.read_csv(os.path.join(qc_control_metrics_dir, f"{control}_combined_nonzero_mean_stats.csv"))
+    df['fov'] = [i.replace('_' + control, '') for i in list(df['fov'])]
+    log2_norm_df: pd.DataFrame = df.pivot(
+        index="channel", columns="fov", values="Non-zero mean intensity"
+    ).transform(func=lambda row: np.log2(row / row.mean()), axis=1)
+    if control != 'tonsil_bottom_duplicate1':
+        dup_col = [col for col in log2_norm_df.columns if 'duplicate1' in col]
+        log2_norm_df = log2_norm_df.drop(columns=dup_col) if dup_col else log2_norm_df
+
+    mean_t_df: pd.DataFrame = (
+        log2_norm_df.mean(axis=0)
+        .to_frame(name="mean")
+        .transpose()
+        .sort_values(by="mean", axis=1)
+    )
+    transformed_df: pd.DataFrame = pd.concat(
+        objs=[log2_norm_df, mean_t_df]
+    ).sort_values(by="mean", axis=1, inplace=False)
+    transformed_df.rename_axis("channel", axis=0, inplace=True)
+    transformed_df.rename_axis("fov", axis=1, inplace=True)
+
+    dfs.append(transformed_df)
+all_data = pd.concat(dfs).replace([np.inf, -np.inf], 0, inplace=True)
+all_data = all_data.groupby(['channel']).mean()
+all_data = all_data.sort_values(by="mean", axis=1, inplace=False).round(2)
+
+
+fig = plt.figure(figsize=(12,12), dpi=300)
+fig.set_layout_engine(layout="constrained")
+gs = gridspec.GridSpec(nrows=2, ncols=1, figure=fig, height_ratios=[len(all_data.index) - 1, 1])
+_norm = Normalize(vmin=-1, vmax=1)
+_cmap = sns.color_palette("vlag", as_cmap=True)
+fig.suptitle(f"Average per TMA - QC: Non-zero Mean Intensity ")
+
+annotation_kws = {
+    "horizontalalignment": "center",
+    "verticalalignment": "center",
+    "fontsize": 8,
+}
+
+ax_heatmap = fig.add_subplot(gs[0, 0])
+sns.heatmap(
+    data=all_data[~all_data.index.isin(["mean"])],
+    ax=ax_heatmap,
+    linewidths=1,
+    linecolor="black",
+    cbar_kws={"shrink": 0.5},
+    annot=True,
+    annot_kws=annotation_kws,
+    xticklabels=False,
+    norm=_norm,
+    cmap=_cmap,
+)
+
+ax_heatmap.collections[0].colorbar.ax.set_title(r"$\log_2(QC)$")
+ax_heatmap.set_yticks(
+    ticks=ax_heatmap.get_yticks(),
+    labels=ax_heatmap.get_yticklabels(),
+    rotation=0,
+)
+ax_heatmap.set_xlabel(None)
+
+ax_avg = fig.add_subplot(gs[1, 0])
+sns.heatmap(
+    data=all_data[all_data.index.isin(["mean"])],
+    ax=ax_avg,
+    linewidths=1,
+    linecolor="black",
+    annot=True,
+    annot_kws=annotation_kws,
+    fmt=".2f",
+    cmap=ListedColormap(["white"]),
+    cbar=False,
+)
+ax_avg.set_yticks(
+    ticks=ax_avg.get_yticks(),
+    labels=["Mean"],
+    rotation=0,
+)
+ax_avg.set_xticks(
+    ticks=ax_avg.get_xticks(),
+    labels=ax_avg.get_xticklabels(),
+    rotation=45,
+    ha="right",
+    rotation_mode="anchor",
+)
+ax_heatmap.set_ylabel("Channel")
+ax_avg.set_xlabel("FOV")
+
+fig.savefig(fname=os.path.join(qc_control_metrics_dir, "figures/log2_avgs.png"), dpi=300,
+            bbox_inches="tight")
+
 
 # Image processing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@
 matplotlib_venn
 #git+https://github.com/angelolab/ark-analysis.git@v0.6.3
 git+https://github.com/angelolab/ark-analysis.git@ce642b04e9a6df750db7dbcf50828417378f8488
+git+https://github.com/angelolab/toffy.git@265d40277ff7156d3e9c8d8a6cfbbaf635cf4333


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Adds code to generate supplemental QC batch effects figures.

**How did you implement your changes**

Added cross TMA spatial comparison in angelolab/toffy#458. The code for TMA data across various control types is added to generate_supplementary_plots.py.
Output for cross control data:
![log2_avgs](https://github.com/angelolab/TNBC_python_scripts/assets/38049893/f0beeb5b-0765-4868-8a30-4b4bb8ca6458)

Final plots are stored on the NAS in `TONIC_Cohort/supplementary_figs/QC_metrics/tma_metrics` and `TONIC_Cohort/supplementary_figs/QC_metrics/longitudinal_control_metrics`.

**Remaining issues**

NA
