### PR TITLE
Generate a stitched image of a pre- and post-Rosetta channel, along with source

### DIFF
--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import matplotlib
 from ark.utils.plot_utils import cohort_cluster_plot
-# from toffy import qc_comp, qc_metrics_plots
+from toffy import qc_comp, qc_metrics_plots
 from alpineer import io_utils
 
 
@@ -220,17 +220,23 @@ run_name = "2022-01-14_TONIC_TMA2_run1"
 pre_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/extracted"
 post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 
-channels = [
-    "CD8", "CD20", "CD3", "CD163", "CD38", "CD56", "TIM3", "GLUT1", "HLADR", "CD31", "FOXP3",
-    "CD11c", "IDO", "CD69", "CD4", "PD1", "CD4"
-]
-for channel in channels:
-    # NOTE: image not scaled up, this happens in Photoshop
-    supplementary_plot_helpers.stitch_before_after_rosetta(
-        pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-        channel, post_rosetta_subdir="normalized", padding=0, step=1
-    )
-
+# NOTE: images not scaled up programmatically, this happens manually in Photoshop
+supplementary_plot_helpers.stitch_before_after_rosetta(
+    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    [11, 20, 35], "CD4", post_rosetta_subdir="normalized", padding=0, step=1
+)
+supplementary_plot_helpers.stitch_before_after_rosetta(
+    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    [17, 18, 39], "CD56", post_rosetta_subdir="normalized", padding=0, step=1
+)
+supplementary_plot_helpers.stitch_before_after_rosetta(
+    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    [30, 45], "CD31", post_rosetta_subdir="normalized", padding=0, step=1
+)
+supplementary_plot_helpers.stitch_before_after_rosetta(
+    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    [11, 15, 17, 20, 30, 42, 43], "CD8", post_rosetta_subdir="normalized", padding=0, step=1
+)
 
 ## show a run with images stitched in acquisition order pre- and post-normalization
 acquisition_order_viz_dir_norm = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order_norm")
@@ -241,10 +247,13 @@ run_name = "2022-01-14_TONIC_TMA2_run1"
 pre_norm_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 post_norm_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/normalized"
 
-# NOTE: image not scaled up, this happens in Photoshop
+# NOTE: images not scaled up programmatically, this happens manually in Photoshop
 supplementary_plot_helpers.stitch_before_after_norm(
     pre_norm_dir, post_norm_dir, acquisition_order_viz_dir_norm, run_name,
-    "H3K9ac", pre_norm_subdir="normalized", padding=0, step=1
+    [
+        11, 12, 13, 14, 15, 17, 18, 20, 22, 23, 24, 28, 29, 30, 31, 32, 33, 34, 35,
+        36, 39, 40, 41, 42, 43, 44, 45, 46, 47
+    ], "H3K9ac", pre_norm_subdir="normalized", padding=0, step=1
 )
 
 

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -211,10 +211,10 @@ fig.savefig(fname=os.path.join(qc_control_metrics_dir, "figures/log2_avgs.png"),
 
 
 # Image processing
-## show a run with images stitched in acquisition order pre- and post-Rosetta
-acquisition_order_viz_dir_rosetta = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order_rosetta")
-if not os.path.exists(acquisition_order_viz_dir_rosetta):
-    os.makedirs(acquisition_order_viz_dir_rosetta)
+## show a run with images pre- and post-Rosetta
+rosetta_tiling = os.path.join(SUPPLEMENTARY_FIG_DIR, "rosetta_tiling")
+if not os.path.exists(rosetta_before_after_viz):
+    os.makedirs(rosetta_before_after_viz)
 
 run_name = "2022-01-14_TONIC_TMA2_run1"
 pre_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/extracted"
@@ -222,28 +222,28 @@ post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 
 # NOTE: images not scaled up programmatically, this happens manually in Photoshop
 supplementary_plot_helpers.stitch_before_after_rosetta(
-    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    pre_rosetta_dir, post_rosetta_dir, rosetta_tiling, run_name,
     [11, 20, 35], "CD4", post_rosetta_subdir="normalized", padding=0, step=1,
     save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
-    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    pre_rosetta_dir, post_rosetta_dir, rosetta_tiling, run_name,
     [17, 18, 39], "CD56", post_rosetta_subdir="normalized", padding=0, step=1,
     save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
-    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    pre_rosetta_dir, post_rosetta_dir, rosetta_tiling, run_name,
     [30, 45], "CD31", post_rosetta_subdir="normalized", padding=0, step=1,
     save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
-    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    pre_rosetta_dir, post_rosetta_dir, rosetta_tiling, run_name,
     [11, 15, 17, 20, 30, 42, 43], "CD8", post_rosetta_subdir="normalized", padding=0, step=1,
     save_separate=True
 )
 
 ## show a run with images stitched in acquisition order pre- and post-normalization
-acquisition_order_viz_dir_norm = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order_norm")
+norm_tiling = os.path.join(SUPPLEMENTARY_FIG_DIR, "norm_tiling")
 if not os.path.exists(acquisition_order_viz_dir_norm):
     os.makedirs(acquisition_order_viz_dir_norm)
 
@@ -253,7 +253,7 @@ post_norm_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/normalized"
 
 # NOTE: images not scaled up programmatically, this happens manually in Photoshop
 supplementary_plot_helpers.stitch_before_after_norm(
-    pre_norm_dir, post_norm_dir, acquisition_order_viz_dir_norm, run_name,
+    pre_norm_dir, post_norm_dir, norm_tiling, run_name,
     [
         11, 12, 13, 14, 15, 17, 18, 20, 22, 23, 24, 28, 29, 30, 31, 32, 33, 34, 35,
         36, 39, 40, 41, 42, 43, 44, 45, 46, 47

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -223,19 +223,23 @@ post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 # NOTE: images not scaled up programmatically, this happens manually in Photoshop
 supplementary_plot_helpers.stitch_before_after_rosetta(
     pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    [11, 20, 35], "CD4", post_rosetta_subdir="normalized", padding=0, step=1
+    [11, 20, 35], "CD4", post_rosetta_subdir="normalized", padding=0, step=1,
+    save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
     pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    [17, 18, 39], "CD56", post_rosetta_subdir="normalized", padding=0, step=1
+    [17, 18, 39], "CD56", post_rosetta_subdir="normalized", padding=0, step=1,
+    save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
     pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    [30, 45], "CD31", post_rosetta_subdir="normalized", padding=0, step=1
+    [30, 45], "CD31", post_rosetta_subdir="normalized", padding=0, step=1,
+    save_separate=True
 )
 supplementary_plot_helpers.stitch_before_after_rosetta(
     pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    [11, 15, 17, 20, 30, 42, 43], "CD8", post_rosetta_subdir="normalized", padding=0, step=1
+    [11, 15, 17, 20, 30, 42, 43], "CD8", post_rosetta_subdir="normalized", padding=0, step=1,
+    save_separate=True
 )
 
 ## show a run with images stitched in acquisition order pre- and post-normalization

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -211,19 +211,34 @@ fig.savefig(fname=os.path.join(qc_control_metrics_dir, "figures/log2_avgs.png"),
 
 
 # Image processing
+## show a run with images stitched in acquisition order pre- and post-Rosetta
+acquisition_order_viz_dir_rosetta = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order_rosetta")
+if not os.path.exists(acquisition_order_viz_dir_rosetta):
+    os.makedirs(acquisition_order_viz_dir_rosetta)
+
+run_name = "2022-01-14_TONIC_TMA2_run1"
+pre_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/extracted"
+post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
+
+# NOTE: image not scaled up, this happens in Photoshop
+supplementary_plot_helpers.stitch_before_after_rosetta(
+    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+    "H3K9ac", post_rosetta_subdir="normalized", padding=0, step=1
+)
+
+
 ## show a run with images stitched in acquisition order pre- and post-normalization
-acquisition_order_viz_dir = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order")
-if not os.path.exists(acquisition_order_viz_dir):
-    os.makedirs(acquisition_order_viz_dir)
+acquisition_order_viz_dir_norm = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order_norm")
+if not os.path.exists(acquisition_order_viz_dir_norm):
+    os.makedirs(acquisition_order_viz_dir_norm)
 
 run_name = "2022-01-14_TONIC_TMA2_run1"
 pre_norm_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 post_norm_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/normalized"
-save_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Cohort/supplementary_figs"
 
 # NOTE: image not scaled up, this happens in Photoshop
 supplementary_plot_helpers.stitch_before_after_norm(
-    pre_norm_dir, post_norm_dir, acquisition_order_viz_dir, run_name,
+    pre_norm_dir, post_norm_dir, acquisition_order_viz_dir_norm, run_name,
     "H3K9ac", pre_norm_subdir="normalized", padding=0, step=1
 )
 

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -243,7 +243,7 @@ supplementary_plot_helpers.stitch_before_after_rosetta(
 )
 
 ## show a run with images stitched in acquisition order pre- and post-normalization
-norm_tiling = os.path.join(SUPPLEMENTARY_FIG_DIR, "norm_tiling")
+norm_tiling = os.path.join(SUPPLEMENTARY_FIG_DIR, "acquisition_order")
 if not os.path.exists(acquisition_order_viz_dir_norm):
     os.makedirs(acquisition_order_viz_dir_norm)
 

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -223,7 +223,7 @@ post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 # NOTE: image not scaled up, this happens in Photoshop
 supplementary_plot_helpers.stitch_before_after_rosetta(
     pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    "H3K9ac", post_rosetta_subdir="normalized", padding=0, step=1
+    "CD8", post_rosetta_subdir="normalized", padding=0, step=1
 )
 
 

--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -220,11 +220,16 @@ run_name = "2022-01-14_TONIC_TMA2_run1"
 pre_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/extracted"
 post_rosetta_dir = "/Volumes/Shared/Noah Greenwald/TONIC_Acquisition/rosetta"
 
-# NOTE: image not scaled up, this happens in Photoshop
-supplementary_plot_helpers.stitch_before_after_rosetta(
-    pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
-    "CD8", post_rosetta_subdir="normalized", padding=0, step=1
-)
+channels = [
+    "CD8", "CD20", "CD3", "CD163", "CD38", "CD56", "TIM3", "GLUT1", "HLADR", "CD31", "FOXP3",
+    "CD11c", "IDO", "CD69", "CD4", "PD1", "CD4"
+]
+for channel in channels:
+    # NOTE: image not scaled up, this happens in Photoshop
+    supplementary_plot_helpers.stitch_before_after_rosetta(
+        pre_rosetta_dir, post_rosetta_dir, acquisition_order_viz_dir_rosetta, run_name,
+        channel, post_rosetta_subdir="normalized", padding=0, step=1
+    )
 
 
 ## show a run with images stitched in acquisition order pre- and post-normalization

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -402,8 +402,8 @@ def stitch_before_after_rosetta(
     pre_rosetta_data = pre_rosetta_data[ACQUISITION_ORDER_INDICES_NORM, ...]
     post_rosetta_data = post_rosetta_data[ACQUISITION_ORDER_INDICES_NORM, ...]
 
-    # multiple post-Rosetta by 200 to ensure same scale
-    post_rosetta_data = post_rosetta_data * 200
+    # divide pre-Rosetta by 200 to ensure same scale
+    pre_rosetta_data = pre_rosetta_data / 200
 
     # reassign coordinate with FOV names that don't contain "-scan-1" or additional dashes
     fovs_condensed: np.ndarray = np.array([f"FOV{af.split('-')[1]}" for af in all_fovs])
@@ -438,41 +438,15 @@ def stitch_before_after_rosetta(
         source_percentile: float = np.percentile(stitched_noodle, percent_norm)
         non_source_percentile: float = np.percentile(stitched_pre_post_rosetta, percent_norm)
         perc_ratio: float = source_percentile / non_source_percentile
-        print(f"The perc_ratio used is: {perc_ratio}")
         stitched_noodle = stitched_noodle / perc_ratio
 
     # combine the Noodle data with the stitched data, swap so that Noodle is in the middle
     stitched_pre_post_rosetta = np.vstack(
         (stitched_pre_post_rosetta[:2048, :], stitched_noodle, stitched_pre_post_rosetta[2048:, :])
     )
-    # stitched_pre_post_rosetta = np.concatenate([stitched_pre_post_rosetta, stitched_noodle])
-    # stitched_pre_post_rosetta[2048:4096], stitched_pre_post_rosetta[4096:8192] = \
-    #     stitched_pre_post_rosetta[4096:8192], stitched_pre_post_rosetta[2048:4096]
 
-    # annotate tiled image to indicate what the rows mean
+    # save the image
     stitched_rosetta_pil: Image = Image.fromarray(np.round(stitched_pre_post_rosetta, 3))
-    imdraw: ImageDraw = ImageDraw.Draw(stitched_rosetta_pil)
-    imfont: ImageFont = ImageFont.truetype("Arial Unicode.ttf", font_size)
-    min_fill_value: int = np.min(stitched_pre_post_rosetta)
-    max_fill_value: int = np.max(stitched_pre_post_rosetta)
-    imdraw.text(
-        (5, 5),
-        f"{target_channel} pre-Rosetta",
-        font=imfont,
-        fill=max_fill_value
-    )
-    imdraw.text(
-        (5, 2053),
-        f"{source_channel} (noise to remove)",
-        font=imfont,
-        fill=max_fill_value
-    )
-    imdraw.text(
-        (5, 4101),
-        f"{target_channel} post-Rosetta",
-        font=imfont,
-        fill=max_fill_value
-    )
     stitched_rosetta_pil.save(rosetta_stitched_path)
 
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses 4.1.3 of #10.

**How did you implement your changes**

Add a function to `supplementary_plot_helpers.py` called `stitch_before_after_rosetta`, which provides nearly the same functionality except with the addition of Noodle channel stitching.

Renamed variables to distinguish between pre- and post-Rosetta vs pre- and post-normalization.

**Remaining issues**

Images still need to be manually scaled up in Photoshop. Ongoing discussions about which run works best.