### PR TITLE
HnE Core, FOV, Segmentation Overlay Plots

### DIFF
--- a/python_files/generate_supplementary_plots.py
+++ b/python_files/generate_supplementary_plots.py
@@ -430,6 +430,22 @@ for fov in fovs_seg:
     )
     p.make_plot(save_dir = save_dir)
 
+# HnE Core, FOV and Segmentation Overlays
+hne_fovs = [
+    "TONIC_TMA2_R7C4",
+    "TONIC_TMA4_R11C2",
+    "TONIC_TMA4_R12C4",
+    "TONIC_TMA24_R2C3",
+]
+hne_path = Path(SUPPLEMENTARY_FIG_DIR) / "hne_core_fov_plots" / " cores_fov_seg_maps"
+seg_dir = Path("/Volumes/Shared/Noah Greenwald/TONIC_Cohort/segmentation_data/")
+
+save_dir = Path(SUPPLEMENTARY_FIG_DIR) / "hne_core_fov_plots" / "figures"
+save_dir.mkdir(exist_ok=True, parents=True)
+for fov in hne_fovs:
+    supplementary_plot_helpers.CorePlot(
+        fov=fov, hne_path=hne_path, seg_dir=seg_dir
+    ).make_plot(save_dir=save_dir)
 
 # Functional marker thresholding
 cell_table = pd.read_csv(


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Generates ROI plots for a given core, a cropped image, and the matching MIBI Nuclear + Membrane Segmentation Overlay image.


**How did you implement your changes**

Used qpath to generate the ROI and the HnE FOV Crop, and plotted the crop zone with GeoPandas and Matplotlib.

Used the following FOVs:
- TONIC_TMA2_R7C4
- TONIC_TMA4_R11C2
- TONIC_TMA4_R12C4
- TONIC_TMA24_R2C3

Sample Plot:

![image](https://github.com/angelolab/TNBC_python_scripts/assets/8909315/30f6158b-741d-4917-ab17-d48abacceda9)


The figures are located in _`TONIC_Cohort/supplementary_figs/hne_core_fov_plots/figures`_.

**Remaining issues**

N/A