### PR TITLE
Average cell counts per timepoint plots

### DIFF
--- a/python_files/generate_supp_figure_6.py
+++ b/python_files/generate_supp_figure_6.py
@@ -76,6 +76,8 @@ for metric in ['Localization', 'Timepoint']:
 
 ## average cell counts by timepoint
 for cluster_level in ['cell_cluster_broad', 'cell_cluster']:
+    cell_table = pd.read_csv('/Volumes/Shared/Noah Greenwald/TONIC_Cohort/analysis_files/cell_table_clusters.csv')
+
     # get cell population and whole image counts
     cell_table = cell_table[['fov', cluster_level, 'cell_meta_cluster']]
     cell_counts = cell_table.groupby(by=['fov', cluster_level]).count().reset_index()


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Generate a plot to show the average counts for each cell population, as well as the total count, for each timepoint classification.

Plots are saved in `supplementary_figs/cluster_stats` as pdfs.

![avg_cells_per_timepoint-broad](https://github.com/user-attachments/assets/04da1d15-a12b-419a-811c-1bf7f4b4365f)
![avg_cells_per_timepoint-cell_cluster](https://github.com/user-attachments/assets/ae854189-00d9-421a-b523-493050758ac9)
