### PR TITLE
Add visualization for diversity and mixing score distributions based on pixel radius changes

### DIFF
--- a/python_files/generate_supp_figure_13.py
+++ b/python_files/generate_supp_figure_13.py
@@ -1,0 +1,40 @@
+import matplotlib
+matplotlib.rcParams['pdf.fonttype'] = 42
+matplotlib.rcParams['ps.fonttype'] = 42
+
+import numpy as np
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from matplotlib_venn import venn3
+
+import python_files.supplementary_plot_helpers as supplementary_plot_helpers
+
+
+BASE_DIR = "/Volumes/Shared/Noah Greenwald/TONIC_Cohort/"
+INTERMEDIATE_DIR = os.path.join(BASE_DIR, "intermediate_files")
+SUPPLEMENTARY_FIG_DIR = os.path.join(BASE_DIR, "supplementary_figs")
+dist_mat_dir = os.path.join(INTERMEDIATE_DIR, "spatial_analysis", "dist_mats")
+
+# Neighborhood/diversity tuning
+neighbors_mat_dir = os.path.join(SUPPLEMENTARY_FIG_DIR, "supp_figure_13_data")
+diversity_mixing_pipeline_tuning_dir = os.path.join(
+    SUPPLEMENTARY_FIG_DIR, "supp_figure_13_robustness"
+)
+if not os.path.exists(neighbors_mat_dir):
+    os.makedirs(neighbors_mat_dir)
+if not os.path.exists(diversity_mixing_pipeline_tuning_dir):
+    os.makedirs(diversity_mixing_pipeline_tuning_dir)
+
+# vary the parameters for each marker threshold
+cell_table_full = pd.read_csv(os.path.join(BASE_DIR, "analysis_files/cell_table_clusters.csv"))
+supplementary_plot_helpers.run_diversity_mixing_tuning_tests(
+    cell_table_full, dist_mat_dir=dist_mat_dir,
+    neighbors_mat_dir=neighbor_mat_dir,
+    save_dir=diversity_mixing_pipeline_tuning_dir,
+    threshold_mults=[1/4, 1/2, 3/4, 7/8, 1, 8/7, 4/3, 2, 4],
+    mixing_info=supplementary_plot_helpers.MIXING_INFO,
+    base_pixel_radius=50, cell_type_col="cell_cluster_broad"
+)

--- a/python_files/generate_supp_figure_13.py
+++ b/python_files/generate_supp_figure_13.py
@@ -2,13 +2,8 @@ import matplotlib
 matplotlib.rcParams['pdf.fonttype'] = 42
 matplotlib.rcParams['ps.fonttype'] = 42
 
-import numpy as np
 import os
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-
-from matplotlib_venn import venn3
 
 import python_files.supplementary_plot_helpers as supplementary_plot_helpers
 
@@ -32,7 +27,7 @@ if not os.path.exists(diversity_mixing_pipeline_tuning_dir):
 cell_table_full = pd.read_csv(os.path.join(BASE_DIR, "analysis_files/cell_table_clusters.csv"))
 supplementary_plot_helpers.run_diversity_mixing_tuning_tests(
     cell_table_full, dist_mat_dir=dist_mat_dir,
-    neighbors_mat_dir=neighbor_mat_dir,
+    neighbors_mat_dir=neighbors_mat_dir,
     save_dir=diversity_mixing_pipeline_tuning_dir,
     threshold_mults=[1/4, 1/2, 3/4, 7/8, 1, 8/7, 4/3, 2, 4],
     mixing_info=supplementary_plot_helpers.MIXING_INFO,

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1279,19 +1279,14 @@ def run_diversity_mixing_tuning_tests(
             )
             mixing_pixel_radius_data[pixel_radius]["mixing_scores"].extend(scores)
 
-    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json"), "w") as outfile:
-        json.dump(diversity_pixel_radius_data, outfile)
-    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json"), "w") as outfile:
-        json.dump(mixing_pixel_radius_data, outfile)
-
     # plot the diversity score experiments
     data_diversity = []
     cell_cluster_types = []
     labels_diversity = []
     for i, (_, diversity_score_data) in enumerate(diversity_pixel_radius_data.items()):
-        data_diversity.append(diversity_score_data["diversity_scores"])
-        cell_cluster_types.append(diversity_score_data[cell_type_col])
-        labels_diversity.append(
+        data_diversity.extend(diversity_score_data["diversity_scores"])
+        cell_cluster_types.extend(diversity_score_data[cell_type_col])
+        labels_diversity.extend(
             [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
         )
 
@@ -1323,7 +1318,7 @@ def run_diversity_mixing_tuning_tests(
     )
     plt.savefig(
         pathlib.Path(save_dir) /
-        f"diversity_cell_cluster_broad_box.pdf",
+        f"neighborhood_diversity_cell_cluster_broad_box.pdf",
         dpi=300
     )
 
@@ -1332,10 +1327,10 @@ def run_diversity_mixing_tuning_tests(
     mixing_score_types = []
     labels_mixing = []
     for i, (_, mixing_score_data) in enumerate(mixing_pixel_radius_data.items()):
-        data_diversity.append(mixing_score_data["mixing_scores"])
-        mixing_score_types.append(mixing_score_data["mixing_score_type"])
-        labels_mixing.append(
-            [threshold_mult_strs[i]] * len(mixing_score_data["mixing_score_type"])
+        data_mixing.extend(mixing_score_data["mixing_scores"])
+        mixing_score_types.extend(mixing_score_data["mixing_score_type"])
+        labels_mixing.extend(
+            [threshold_mult_strs[i]] * len(mixing_score_data["mixing_scores"])
         )
 
     plt.figure(figsize=(25, 15))

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1221,11 +1221,6 @@ def run_diversity_mixing_tuning_tests(
             "mixing_scores": []
         } for pr in pixel_radii}
 
-    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json")) as infile:
-        diversity_pixel_radius_data = json.load(infile)
-    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json")) as infile:
-        mixing_pixel_radius_data = json.load(infile)
-
     # iterate over each pixel radii
     for i, pixel_radius in enumerate(pixel_radii):
         # the diversity score calculation requires saving out the neighbor matrix
@@ -1300,11 +1295,6 @@ def run_diversity_mixing_tuning_tests(
                 [f"{mixing_prefix}_mixing_score"] * len(scores)
             )
             mixing_pixel_radius_data[pixel_radius]["mixing_scores"].extend(scores)
-
-    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json"), "w") as outfile:
-        json.dump(diversity_pixel_radius_data, outfile, indent=4)
-    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json"), "w") as outfile:
-        json.dump(mixing_pixel_radius_data, outfile, indent=4)
 
     # plot the diversity score experiments
     data_diversity = []

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1313,7 +1313,7 @@ def run_diversity_mixing_tuning_tests(
     )
     plt.savefig(
         pathlib.Path(save_dir) /
-        f"neighborhood_diversity_cell_cluster_broad_box.pdf",
+        f"diversity_cell_cluster_broad_box.pdf",
         dpi=300
     )
 

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -183,7 +183,6 @@ MIXING_INFO = {
     'Cancer_Structural': (['Cancer'], ['Structural']),
     'Structural_Immune': (['Structural'], ['T', 'B', 'Mono_Mac', 'NK', 'Granulocyte']),
     'Structural_T': (['Structural'], ['T']),
-    'Structural_B': (['Structural'], ['B']),
     'Structural_Mono_Mac': (['Structural'], ['Mono_Mac'])
 }
 
@@ -1316,6 +1315,7 @@ def run_diversity_mixing_tuning_tests(
         title_fontsize=24,
         fontsize=18
     )
+    plt.tight_layout()
     plt.savefig(
         pathlib.Path(save_dir) /
         f"neighborhood_diversity_cell_cluster_broad_box.pdf",
@@ -1359,6 +1359,8 @@ def run_diversity_mixing_tuning_tests(
         title_fontsize=24,
         fontsize=18
     )
+    plt.tight_layout()
+
     plt.savefig(
         pathlib.Path(save_dir) /
         f"mixing_score_cell_cluster_broad_box.pdf",

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1283,10 +1283,10 @@ def run_diversity_mixing_tuning_tests(
     cell_cluster_types = []
     labels_diversity = []
     for i, diversity_score_data in enumerate(diversity_pixel_radius_data):
-        data_diversity.append(diversity_score_data["diversity_scores"])
-        cell_cluster_types.append(diversity_score_data[cell_type_col])
+        data_diversity.append(diversity_pixel_radius_data["diversity_scores"])
+        cell_cluster_types.append(diversity_pixel_radius_data[cell_type_col])
         labels_diversity.append(
-            [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
+            [threshold_mult_strs[i]] * len(diversity_pixel_radius_data["diversity_scores"])
         )
 
     plt.figure(figsize=(25, 15))
@@ -1325,7 +1325,7 @@ def run_diversity_mixing_tuning_tests(
     data_mixing = []
     mixing_score_types = []
     labels_mixing = []
-    for i, mixing_score_data in enumerate(diversity_pixel_radius_data):
+    for i, mixing_score_data in enumerate(mixing_score_data):
         data_diversity.append(mixing_score_data["mixing_scores"])
         mixing_score_types.append(mixing_score_data["mixing_score_type"])
         labels_mixing.append(

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -20,6 +20,12 @@ from PIL import Image, ImageDraw, ImageFont
 from typing import Dict, List, Optional, Tuple, TypedDict, Union, Literal
 from skimage.io import imread
 import geopandas as gpd
+from ark.analysis.neighborhood_analysis import (
+    create_neighborhood_matrix,
+    compute_cell_ratios,
+    compute_mixing_score
+)
+from ark.analysis.cell_neighborhood_stats import generate_neighborhood_diversity_analysis
 from ark.utils import plot_utils, data_utils
 from alpineer.io_utils import list_folders, list_files, remove_file_extensions, validate_paths
 from alpineer.load_utils import load_imgs_from_tree, load_imgs_from_dir
@@ -173,6 +179,15 @@ MARKER_INFO = {
         "x_ticks": np.array([0, 0.1, 0.2, 0.3]),
         "x_tick_labels": np.array([0, 0.1, 0.2, 0.3]),
     }
+}
+
+MIXING_INFO = {
+    'Cancer_Immune': (['Cancer'], ['T', 'B', 'Mono_Mac', 'NK', 'Granulocyte']),
+    'Cancer_Structural': (['Cancer'], ['Structural']),
+    'Structural_Immune': (['Structural'], ['T', 'B', 'Mono_Mac', 'NK', 'Granulocyte']),
+    'Structural_T': (['Structural'], ['T']),
+    'Structural_B': (['Structural'], ['B']),
+    'Structural_Mono_Mac': (['Structural'], ['Mono_Mac'])
 }
 
 # generate stitching/annotation function, used by panel validation and acquisition order tiling
@@ -1138,6 +1153,125 @@ def run_cancer_mask_inclusion_tests(
         pathlib.Path(save_dir) / f"border_size_cancer_region_percentages_box.pdf",
         dpi=300
     )
+
+
+def run_diversity_mixing_tuning_tests(
+    cell_table: pd.DataFrame, dist_mat_dir: Union[str, pathlib.Path],
+    neighbors_mat_dir: Union[str, pathlib.Path],
+    save_dir: Union[str, pathlib.Path], threshold_mults: List[float],
+    mixing_info: Dict[Tuple[List[str], List[str]]],
+    base_pixel_radius: int = 50, cell_type_col: str = "cell_cluster_broad"
+):
+    """Create grouped box plots showing how much changing the pixel radius parameter for 
+    neighborhood analysis affects the distributions of the downstream diversity scores and 
+    mixing scores. Two separate box plots are created for each, and the grouping happens 
+    by the specified `cluster_col`.
+
+    NOTE: the bins (30), ratio_threshold (5), and cell_count_threshold (200) parameters 
+    for the mixing score pipeline are held constant.
+
+    Args:
+        cell_table (pd.DataFrame):
+            Cell table with clustered cell populations
+        dist_mat_dir (Union[str, pathlib.Path]):
+            The folder containing the distance matrices used for neighborhood analysis
+        neighbors_mat_dir (Union[str, pathlib.Path]):
+            The folder containing the intermediate neighborhood matrices
+            # NOTE: this is needed to run `generate_neighborhood_diversity_analysis` correctly
+        save_dir (Union[str, pathlib.Path]):
+            The directory to save the box plots
+        threshold_mults (List[float]):
+            What value to multiply the base params to test in this function
+        mixing_populations (Dict[Tuple[List[str], List[str]]]):
+            What populations to include for mixing of each cell type
+        base_pixel_radius (int):
+            The pixel radius currently used for neighborhood analysis
+        cell_type_col (str):
+            The column used to group the boxplot by
+    """
+    # define each pixel radii to test
+    pixel_radii = [base_pixel_radius * tm for tm in threshold_mults]
+
+    # define lists to store the diversity and mixing scores respectively
+    diversity_scores = {pr: [] for pr in pixel_radii}
+    mixing_scores = {pr: [] for pr in pixel_radii}
+
+    # iterate over each pixel radii
+    for i, pixel_radius in enumerate(pixel_radii):
+        # create the neighborhood matrix with the given pixel radius
+        neighbor_counts, neighbor_freqs = create_neighborhood_matrix(
+            all_data,
+            dist_mat_dir,
+            included_fovs=all_data["fov"].unique(),
+            distlim=pixel_radius,
+            cell_type_col=cell_type_col
+        )
+
+        # the diversity score calculation requires saving out the neighbor matrix
+        ## TODO: save neighbor counts and neighbor freqs to specified folder
+        counts_path = os.path.join(
+            neighbors_mat_dir, f"neighborhood_counts-{cell_type_col}_radius{pixel_radius}.csv"
+        )
+        freqs_path = os.path.join(
+            neighbors_mat_dir, f"neighborhood_freqs-{cell_type_col}_radius{pixel_radius}.csv"
+        )
+        neighbor_counts.to_csv(counts_path, index=False)
+        neighbor_freqs.to_csv(freqs_path, index=False)
+
+        # generate the corresponding diversity score
+        diversity_data = generate_neighborhood_diversity_analysis(
+            neighbors_mat_dir, pixel_radius, [cluster_col]
+        )
+
+        # append the data to the diversity data list, faceted by cell type
+        diversity_scores[pixel_radius].append(
+            list(
+                zip(
+                    list(diversity_data["cell_cluster_broad"]),
+                    list(diversity_data["diversity_cell_cluster_broad"])
+                )
+            )
+        )
+
+        # define the final mixing score DataFrame
+        all_mixing_scores = None
+
+        # iterate over each mixing score populations
+        for mixing_prefix, cells in zip(mixing_info.keys(), mixing_info.values()):
+            population_1_cells, population_2_cells = cells
+
+            # compute the cell ratios between the two
+            ratios = compute_cell_ratios(
+                neighbor_counts, population_1_cells, population_2_cells,
+                fov_list=all_data["fov"].unique(), bin_number=50, cell_col=cell_type_col
+            )
+            ratios = ratios.rename(columns={"cell_ratio": f"{mixing_prefix}_cell_ratio"})
+
+            # compute the mixing scores per FOV
+            scores, counts = [], []
+            for fov in all_fovs:
+                fov_neighbor_counts = neighbor_counts[neighbor_counts["fov"] == fov]
+                fov_score, cell_counts = compute_mixing_score(
+                    fov_neighbor_counts,
+                    population_1_cells,
+                    population_2_cells,
+                    mixing_type,
+                    ratio_threshold=5,
+                    cell_count_thresh=200,
+                    cell_col=cell_type_col
+                )
+                scores.append(fov_score)
+                counts.append(cell_counts)
+
+            # append the data to the mixing score list, associate with mixing score type
+            mixing_scores[pixel_radius].append(
+                list(
+                    zip(
+                        [f"{mixing_prefix}_mixing_score"] * len(scores),
+                        scores
+                    )
+                )
+            )
 
 
 def random_feature_generation(combined_df, seed_num, tonic_features_df, feature_metadata):

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1284,7 +1284,7 @@ def run_diversity_mixing_tuning_tests(
     labels_diversity = []
     for i, (_, diversity_score_data) in enumerate(diversity_pixel_radius_data.items()):
         data_diversity.append(diversity_score_data["diversity_scores"])
-        cell_cluster_types.append(diversity_pixel_radius_data[cell_type_col])
+        cell_cluster_types.append(diversity_score_data[cell_type_col])
         labels_diversity.append(
             [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
         )

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1289,6 +1289,7 @@ def run_diversity_mixing_tuning_tests(
             [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
         )
 
+    sns.set(style="white")
     plt.figure(figsize=(25, 15))
     sns.boxplot(x=labels_diversity, y=data_diversity, hue=cell_cluster_types)
     plt.title(
@@ -1333,6 +1334,7 @@ def run_diversity_mixing_tuning_tests(
             [threshold_mult_strs[i]] * len(mixing_score_data["mixing_scores"])
         )
 
+    sns.set(style="white")
     plt.figure(figsize=(25, 15))
     sns.boxplot(x=labels_mixing, y=data_mixing, hue=mixing_score_types)
     plt.title(

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1283,7 +1283,9 @@ def run_diversity_mixing_tuning_tests(
     for i, diversity_score_data in enumerate(diversity_pixel_radius_data):
         data_diversity.append(diversity_score_data["diversity_scores"])
         cell_cluster_types.append(diversity_score_data[cell_type_col])
-        labels_diversity.append([threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"]))
+        labels_diversity.append(
+            [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
+        )
 
     plt.figure(figsize=(25, 15))
     sns.boxplot(x=labels_diversity, y=data_diversity, hue=cell_cluster_types)
@@ -1324,7 +1326,9 @@ def run_diversity_mixing_tuning_tests(
     for i, mixing_score_data in enumerate(diversity_pixel_radius_data):
         data_diversity.append(mixing_score_data["mixing_scores"])
         mixing_score_types.append(mixing_score_data["mixing_score_type"])
-        labels_mixing.append([threshold_mult_strs[i]] * len(mixing_score_data["mixing_score_type"]))
+        labels_mixing.append(
+            [threshold_mult_strs[i]] * len(mixing_score_data["mixing_score_type"])
+        )
 
     plt.figure(figsize=(25, 15))
     sns.boxplot(x=labels_mixing, y=data_mixing, hue=mixing_score_types)

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -178,6 +178,17 @@ MARKER_INFO = {
     }
 }
 
+DIVERSITY_BROAD_CELL_CLUSTER_ORDER = [
+    "Cancer",
+    "Structural"
+    "B",
+    "Mono_Mac",
+    "Granulocyte",
+    "T",
+    "Other",
+    "NK"
+]
+
 MIXING_INFO = {
     'Cancer_Immune': (['Cancer'], ['T', 'B', 'Mono_Mac', 'NK', 'Granulocyte']),
     'Cancer_Structural': (['Cancer'], ['Structural']),
@@ -185,6 +196,13 @@ MIXING_INFO = {
     'Structural_T': (['Structural'], ['T']),
     'Structural_Mono_Mac': (['Structural'], ['Mono_Mac'])
 }
+MIXING_INTERACTION_ORDER = [
+    "Cancer_Immune_mixing_score",
+    "Cancer_Structural_mixing_score",
+    "Structural_T_mixing_score",
+    "Structural_Mono_Mac_mixing_score",
+    "Structural_Immune_mixing_score"
+]
 
 # generate stitching/annotation function, used by panel validation and acquisition order tiling
 def stitch_and_annotate_padded_img(image_data: xr.DataArray, padding: int = 25,
@@ -1203,6 +1221,11 @@ def run_diversity_mixing_tuning_tests(
             "mixing_scores": []
         } for pr in pixel_radii}
 
+    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json")) as infile:
+        diversity_pixel_radius_data = json.load(infile)
+    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json")) as infile:
+        mixing_pixel_radius_data = json.load(infile)
+
     # iterate over each pixel radii
     for i, pixel_radius in enumerate(pixel_radii):
         # the diversity score calculation requires saving out the neighbor matrix
@@ -1278,6 +1301,11 @@ def run_diversity_mixing_tuning_tests(
             )
             mixing_pixel_radius_data[pixel_radius]["mixing_scores"].extend(scores)
 
+    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json"), "w") as outfile:
+        json.dump(diversity_pixel_radius_data, outfile, indent=4)
+    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json"), "w") as outfile:
+        json.dump(mixing_pixel_radius_data, outfile, indent=4)
+
     # plot the diversity score experiments
     data_diversity = []
     cell_cluster_types = []
@@ -1291,7 +1319,12 @@ def run_diversity_mixing_tuning_tests(
 
     sns.set(style="white")
     plt.figure(figsize=(25, 15))
-    sns.boxplot(x=labels_diversity, y=data_diversity, hue=cell_cluster_types)
+    sns.boxplot(
+        x=labels_diversity,
+        y=data_diversity,
+        hue=cell_cluster_types,
+        hue_order=DIVERSITY_BROAD_CELL_CLUSTER_ORDER
+    )
     plt.title(
         "Distribution of broad cell cluster neighborhood diversity across pixel radius values (1x = 50)",
         fontsize=32,
@@ -1319,7 +1352,7 @@ def run_diversity_mixing_tuning_tests(
     plt.tight_layout()
     plt.savefig(
         pathlib.Path(save_dir) /
-        f"neighborhood_diversity_cell_cluster_broad_box.pdf",
+        f"neighborhood_diversity_cell_cluster_broad_box_test.pdf",
         dpi=300
     )
 
@@ -1336,7 +1369,12 @@ def run_diversity_mixing_tuning_tests(
 
     sns.set(style="white")
     plt.figure(figsize=(25, 15))
-    sns.boxplot(x=labels_mixing, y=data_mixing, hue=mixing_score_types)
+    sns.boxplot(
+        x=labels_mixing,
+        y=data_mixing,
+        hue=mixing_score_types,
+        hue_order=MIXING_INTERACTION_ORDER
+    )
     plt.title(
         "Distribution of broad cell cluster mixing scores across pixel radius values (1x = 50)",
         fontsize=32,
@@ -1365,7 +1403,7 @@ def run_diversity_mixing_tuning_tests(
 
     plt.savefig(
         pathlib.Path(save_dir) /
-        f"mixing_score_cell_cluster_broad_box.pdf",
+        f"mixing_score_cell_cluster_broad_box_test.pdf",
         dpi=300
     )
 

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1282,11 +1282,11 @@ def run_diversity_mixing_tuning_tests(
     data_diversity = []
     cell_cluster_types = []
     labels_diversity = []
-    for i, diversity_score_data in enumerate(diversity_pixel_radius_data):
-        data_diversity.append(diversity_pixel_radius_data["diversity_scores"])
+    for i, (_, diversity_score_data) in enumerate(diversity_pixel_radius_data.items()):
+        data_diversity.append(diversity_score_data["diversity_scores"])
         cell_cluster_types.append(diversity_pixel_radius_data[cell_type_col])
         labels_diversity.append(
-            [threshold_mult_strs[i]] * len(diversity_pixel_radius_data["diversity_scores"])
+            [threshold_mult_strs[i]] * len(diversity_score_data["diversity_scores"])
         )
 
     plt.figure(figsize=(25, 15))
@@ -1325,7 +1325,7 @@ def run_diversity_mixing_tuning_tests(
     data_mixing = []
     mixing_score_types = []
     labels_mixing = []
-    for i, mixing_score_data in enumerate(mixing_score_data):
+    for i, (_, mixing_score_data) in enumerate(mixing_pixel_radius_data.items()):
         data_diversity.append(mixing_score_data["mixing_scores"])
         mixing_score_types.append(mixing_score_data["mixing_score_type"])
         labels_mixing.append(

--- a/python_files/supplementary_plot_helpers.py
+++ b/python_files/supplementary_plot_helpers.py
@@ -1189,6 +1189,7 @@ def run_diversity_mixing_tuning_tests(
     """
     # define each pixel radii to test
     pixel_radii = [base_pixel_radius * tm for tm in threshold_mults]
+    threshold_mult_strs = [str(np.round(np.log2(tm), 3)) for tm in threshold_mults]
 
     # define lists to store the diversity and mixing scores respectively
     diversity_pixel_radius_data = {
@@ -1277,6 +1278,11 @@ def run_diversity_mixing_tuning_tests(
                 [f"{mixing_prefix}_mixing_score"] * len(scores)
             )
             mixing_pixel_radius_data[pixel_radius]["mixing_scores"].extend(scores)
+
+    with open(os.path.join(save_dir, "full_diversity_experiment_dict.json"), "w") as outfile:
+        json.dump(diversity_pixel_radius_data, outfile)
+    with open(os.path.join(save_dir, "full_mixing_experiment_dict.json"), "w") as outfile:
+        json.dump(mixing_pixel_radius_data, outfile)
 
     # plot the diversity score experiments
     data_diversity = []


### PR DESCRIPTION
**What is the purpose of this PR?**

Reviewers for Noah's TNBC paper have requested a figure showing how robust the pixel radius of 50 is in the neighborhood matrix creation is for diversity and mixing score calculations downstream.

**How did you implement your changes**

Add a new supplementary figure generation script (Fig. 13) and add the process in `supplementary_plot_helpers.py`.

The boxplot visualization is very similar for the cancer mask plots, however additional faceting needs to be accounted for.